### PR TITLE
✨ Add rubocop-capybara to the require section

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -39,6 +39,7 @@ AllCops:
 ####
 inherit_from:
   - './rubocop-bundler.yml'
+  - './rubocop-capybara.yml'
   - './rubocop-gemspec.yml'
   - './rubocop-layout.yml'
   - './rubocop-lint.yml'

--- a/config/rubocop-capybara.yml
+++ b/config/rubocop-capybara.yml
@@ -1,0 +1,2 @@
+require:
+  - rubocop-capybara

--- a/rubocop-config-captive.gemspec
+++ b/rubocop-config-captive.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('rubocop-performance', '~> 1.16.0 ')
   gem.add_dependency('rubocop-rails', '~> 2.18.0')
   gem.add_dependency('rubocop-rspec', '~> 2.18.1')
+  gem.add_dependency('rubocop-capybara', '~> 2.17.1')
   gem.add_development_dependency('rspec', '~> 3.5')
   # gem.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
because rubocop-capybara is a dependency of rubocop-rspec

close #7 