### PR TITLE
⚰️ Supprime configuration RSpec/Capybara/CurrentPathExpectation becau…

### DIFF
--- a/config/__private__/rubocop-rspec.yml
+++ b/config/__private__/rubocop-rspec.yml
@@ -310,10 +310,6 @@ RSpec/VoidExpect:
   Description: This cop checks void `expect()`.
   Enabled: false
 
-RSpec/Capybara/CurrentPathExpectation:
-  Description: Checks that no expectations are set on Capybara's `current_path`.
-  Enabled: false
-
 RSpec/Capybara/FeatureMethods:
   Description: Checks for consistent method usage in feature specs.
   Enabled: false


### PR DESCRIPTION
…se it was transfered to Capybara/CurrentPathExpectation

Remove warning : `.../config/__private__/rubocop-rspec.yml: RSpec/Capybara/CurrentPathExpectation has the wrong namespace - should be Capybara`

https://github.com/rubocop/rubocop-rspec/pull/1519