### PR TITLE
✨ Ajoute une alerte Rubocop si un where utilise une string en paramèt…

### DIFF
--- a/config/rubocop-captive.yml
+++ b/config/rubocop-captive.yml
@@ -3,6 +3,7 @@ require:
   - ../lib/rubocop/cop/captive/translation/devise_i18n_presence.rb
   - ../lib/rubocop/cop/captive/translation/rails_i18n_presence.rb
   - ../lib/rubocop/cop/captive/translation/kaminari_i18n_presence.rb
+  - ../lib/rubocop/cop/captive/string_where_in_scope.rb
 
 # ActiveAdmin
 Captive/ActiveAdmin/ActiveAdminAddonsPresence:
@@ -25,3 +26,8 @@ Captive/Translation/KaminariI18nPresence:
   Description: 'The gem `kaminari-i18n` should be added to the Gemfile if `kaminari` is present in Gemfile'
   Include:
     - 'Gemfile'
+
+Captive/StringWhereInScope:
+  Description: 'The `where` method should be used in a scope in a model.'
+  Exclude:
+    - 'app/models/**/*'

--- a/lib/rubocop/cop/captive/string_where_in_scope.rb
+++ b/lib/rubocop/cop/captive/string_where_in_scope.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Captive
+      class StringWhereInScope < RuboCop::Cop::Cop
+        MSG = 'The `where` method should be used in a scope in a model.'
+
+        def_node_matcher :where_with_string?, <<~PATTERN
+          (send _ :where (str _) ...)
+        PATTERN
+
+        def on_send(node)
+          return unless where_with_string?(node)
+
+          options_node = node.arguments[0]
+          return if options_node&.hash_type?
+
+          add_offense(options_node, message: MSG)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/captive/string_where_in_scope_spec.rb
+++ b/spec/rubocop/cop/captive/string_where_in_scope_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RuboCop::Cop::Captive::StringWhereInScope do
+  subject(:cop) { described_class.new }
+
+  it 'does not add offense for hash syntax' do
+    expect_no_offenses('User.where(id: user_ids)')
+  end
+
+  it 'adds offense for string interpolation' do
+    expect_offense(<<~RUBY)
+      User.where('created_at > ?', 1.week.ago)
+                 ^^^^^^^^^^^^^^^^ The `where` method should be used in a scope in a model.
+    RUBY
+  end
+
+  it 'adds offense for hardcoded string' do
+    expect_offense(<<~RUBY)
+      User.where("status IN ('active', 'inactive')")
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `where` method should be used in a scope in a model.
+    RUBY
+  end
+end


### PR DESCRIPTION
…re en dehors d'un model

Si on utilise une string, cela veut dire que l'on écrit du SQL. Le SQL doit être mis dans un model pour respecter le standard MVC