### PR TITLE
✨ Ajoute un cop pour empêcher d'utiliser la variable d'environnement APP_ENV

### DIFF
--- a/config/rubocop-captive.yml
+++ b/config/rubocop-captive.yml
@@ -4,6 +4,7 @@ require:
   - ../lib/rubocop/cop/captive/translation/rails_i18n_presence.rb
   - ../lib/rubocop/cop/captive/translation/kaminari_i18n_presence.rb
   - ../lib/rubocop/cop/captive/string_where_in_scope.rb
+  - ../lib/rubocop/cop/captive/no_app_env.rb
 
 # ActiveAdmin
 Captive/ActiveAdmin/ActiveAdminAddonsPresence:
@@ -27,7 +28,11 @@ Captive/Translation/KaminariI18nPresence:
   Include:
     - 'Gemfile'
 
+# other
 Captive/StringWhereInScope:
   Description: 'The `where` method should be used in a scope in a model.'
   Exclude:
     - 'app/models/**/*'
+
+Captive/NoAppEnv:
+  Description: "Do not use `APP_ENV` environment variable as it conflicts with standard Rails/Rack environment variable `RAILS_ENV`."

--- a/lib/rubocop/cop/captive/no_app_env.rb
+++ b/lib/rubocop/cop/captive/no_app_env.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Captive
+      # This cop checks for usages of the `APP_ENV` environment variable.
+      # Usage of `APP_ENV` is prohibited as it conflicts with standard Rails/Rack
+      # environment variable `RAILS_ENV` and may lead to unexpected results.
+      class NoAppEnv < RuboCop::Cop::Cop
+        MSG = "Do not use `APP_ENV` environment variable as it conflicts with "\
+              "standard Rails/Rack environment variable `RAILS_ENV`."
+
+        def_node_matcher :env_variable?, <<~PATTERN
+          (send
+            (const _ :ENV) {:[] :fetch}
+            (str "APP_ENV")
+            ...
+          )
+        PATTERN
+
+        def on_send(node)
+          return unless env_variable?(node)
+          add_offense(node, message: MSG)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/captive/no_app_env_spec.rb
+++ b/spec/rubocop/cop/captive/no_app_env_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Captive::NoAppEnv do
+  subject(:cop) { described_class.new }
+
+  it 'flags usage of ENV["APP_ENV"]' do
+    expect_offense(<<~RUBY)
+      ENV['APP_ENV']
+      ^^^^^^^^^^^^^^ Captive/NoAppEnv: #{RuboCop::Cop::Captive::NoAppEnv::MSG}
+
+    RUBY
+  end
+
+  it 'flags usage of ENV.fetch("APP_ENV")' do
+    expect_offense(<<~RUBY)
+      ENV.fetch('APP_ENV', 'development')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Captive/NoAppEnv: #{RuboCop::Cop::Captive::NoAppEnv::MSG}
+    RUBY
+  end
+
+  it 'does not flag usage of Rails.env' do
+    expect_no_offenses(<<~RUBY)
+      Rails.env
+    RUBY
+  end
+
+  it 'does not flag usage of other ENV variables' do
+    expect_no_offenses(<<~RUBY)
+      ENV['SOME_OTHER_VAR']
+    RUBY
+  end
+end


### PR DESCRIPTION
Cette variable vient remplacer RAILS_ENV avec Sidekiq !

Ce qui nous a provoqué par le passé des problèmes, qui étaient complexe pour retrouver l'origine