### PR TITLE
✨ Empêche de pouvoir laisser un focus sur une PR

### DIFF
--- a/config/__private__/rubocop-rspec.yml
+++ b/config/__private__/rubocop-rspec.yml
@@ -93,6 +93,9 @@ RSpec/FilePath:
   CustomTransform:
     RuboCop: rubocop
     RSpec: rspec
+RSpec/Focus:
+  Description: Checks if examples are focused.
+  Enabled: false
 RSpec/HookArgument:
   Description: Checks the arguments passed to `before`, `around`, and `after`.
   Enabled: false

--- a/config/rubocop-rspec.yml
+++ b/config/rubocop-rspec.yml
@@ -1,3 +1,6 @@
 inherit_from:
   # @see https://github.com/airbnb/ruby/blob/main/rubocop-airbnb/config/rubocop-rspec.yml
   - ./__private__/rubocop-rspec.yml
+
+RSpec/Focus:
+  Enabled: true


### PR DESCRIPTION
J'ai eu le cas où ma PR a eu un retour car j'ai laissé un focus par erreur : 
https://git.captive.fr/captive/vera/vera-serveur/-/merge_requests/772#note_122671

<img width="1036" alt="Capture d’écran 2023-05-16 à 16 25 32" src="https://github.com/Captive-Studio/rubocop-config/assets/7428736/0629edfd-a3e7-435f-b91b-0249acb14366">