### PR TITLE
✨ Ignore Layout/LineLength for rspec files

### DIFF
--- a/config/rubocop-layout.yml
+++ b/config/rubocop-layout.yml
@@ -43,3 +43,8 @@ Layout/MultilineMethodParameterLineBreaks:
 Layout/LineLength:
   # Disable LineLength on comments
   AllowedPatterns: ['^(\s*#)']
+  Exclude:
+    - '**/*_spec.rb'
+    - '**/*_test.rb'
+    - '**/*_spec.*'
+    - '**/*_test.*'

--- a/config/rubocop-layout.yml
+++ b/config/rubocop-layout.yml
@@ -44,7 +44,7 @@ Layout/LineLength:
   # Disable LineLength on comments
   AllowedPatterns: ['^(\s*#)']
   Exclude:
+    - 'spec/**/*.rb'
+    - 'test/**/*.rb'
     - '**/*_spec.rb'
     - '**/*_test.rb'
-    - '**/*_spec.*'
-    - '**/*_test.*'


### PR DESCRIPTION
- too many false positive on describe, context, it blocks

If line length is too long for tests, it is not an important problem (at first sight)