### PR TITLE
✨ Ajoute la gem rubocop-magic_number pour détecter les nombres magiques

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       rubocop (~> 1.51.0)
       rubocop-capybara (~> 2.18.0)
       rubocop-factory_bot (~> 2.23.1)
+      rubocop-magic_numbers (~> 0.4.0)
       rubocop-performance (~> 1.17.1)
       rubocop-rails (~> 2.18.0)
       rubocop-rake (~> 0.6.0)
@@ -79,6 +80,9 @@ GEM
       rubocop (~> 1.41)
     rubocop-factory_bot (2.23.1)
       rubocop (~> 1.33)
+    rubocop-magic_numbers (0.4.0)
+      parser
+      rubocop
     rubocop-performance (1.17.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -101,6 +105,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/config/default.yml
+++ b/config/default.yml
@@ -45,6 +45,7 @@ inherit_from:
   - './rubocop-gemspec.yml'
   - './rubocop-layout.yml'
   - './rubocop-lint.yml'
+  - './rubocop-magic_numbers.yml'
   - './rubocop-metrics.yml'
   - './rubocop-naming.yml'
   - './rubocop-performance.yml'

--- a/config/rubocop-magic_numbers.yml
+++ b/config/rubocop-magic_numbers.yml
@@ -1,0 +1,25 @@
+require:
+  - rubocop-magic_numbers
+
+MagicNumbers/NoArgument:
+  Enabled: true
+  PermittedValues:
+    - 0
+  Exclude:
+    - spec/**/*_spec.rb
+
+# Cette règle empeche de pouvoir faire des variables d'instances qui servent de compteur
+MagicNumbers/NoAssignment:
+  Enabled: false
+  Exclude:
+    - spec/**/*_spec.rb
+
+MagicNumbers/NoDefault:
+  Enabled: true
+  Exclude:
+    - spec/**/*_spec.rb
+
+MagicNumbers/NoReturn:
+  Enabled: true
+  Exclude:
+    - spec/**/*_spec.rb

--- a/docs/RuboCop.html
+++ b/docs/RuboCop.html
@@ -107,7 +107,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop.html
+++ b/docs/RuboCop.html
@@ -107,7 +107,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Captive.html
+++ b/docs/RuboCop/Captive.html
@@ -144,7 +144,7 @@
 
 </div>
         </dt>
-        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>1.7.0</span><span class='tstring_end'>&quot;</span></span></pre></dd>
+        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>1.8.0</span><span class='tstring_end'>&quot;</span></span></pre></dd>
       
     </dl>
   
@@ -160,7 +160,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Captive.html
+++ b/docs/RuboCop/Captive.html
@@ -160,7 +160,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Captive/Inject.html
+++ b/docs/RuboCop/Captive/Inject.html
@@ -185,7 +185,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Captive/Inject.html
+++ b/docs/RuboCop/Captive/Inject.html
@@ -185,7 +185,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop.html
+++ b/docs/RuboCop/Cop.html
@@ -107,7 +107,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop.html
+++ b/docs/RuboCop/Cop.html
@@ -107,7 +107,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive.html
+++ b/docs/RuboCop/Cop/Captive.html
@@ -109,7 +109,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive.html
+++ b/docs/RuboCop/Cop/Captive.html
@@ -109,7 +109,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/ActiveAdmin.html
+++ b/docs/RuboCop/Cop/Captive/ActiveAdmin.html
@@ -105,7 +105,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/ActiveAdmin.html
+++ b/docs/RuboCop/Cop/Captive/ActiveAdmin.html
@@ -105,7 +105,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/ActiveAdmin/ActiveAdminAddonsPresence.html
+++ b/docs/RuboCop/Cop/Captive/ActiveAdmin/ActiveAdminAddonsPresence.html
@@ -234,7 +234,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/ActiveAdmin/ActiveAdminAddonsPresence.html
+++ b/docs/RuboCop/Cop/Captive/ActiveAdmin/ActiveAdminAddonsPresence.html
@@ -234,7 +234,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/NoAppEnv.html
+++ b/docs/RuboCop/Cop/Captive/NoAppEnv.html
@@ -213,7 +213,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/NoAppEnv.html
+++ b/docs/RuboCop/Cop/Captive/NoAppEnv.html
@@ -213,7 +213,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/RSpec.html
+++ b/docs/RuboCop/Cop/Captive/RSpec.html
@@ -105,7 +105,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/RSpec.html
+++ b/docs/RuboCop/Cop/Captive/RSpec.html
@@ -105,7 +105,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/RSpec/SpecifyBeforeParameter.html
+++ b/docs/RuboCop/Cop/Captive/RSpec/SpecifyBeforeParameter.html
@@ -248,7 +248,7 @@ end</code></pre>
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/RSpec/SpecifyBeforeParameter.html
+++ b/docs/RuboCop/Cop/Captive/RSpec/SpecifyBeforeParameter.html
@@ -248,7 +248,7 @@ end</code></pre>
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/Rails.html
+++ b/docs/RuboCop/Cop/Captive/Rails.html
@@ -107,7 +107,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/Rails.html
+++ b/docs/RuboCop/Cop/Captive/Rails.html
@@ -107,7 +107,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/Rails/ForceSslEnabledInProduction.html
+++ b/docs/RuboCop/Cop/Captive/Rails/ForceSslEnabledInProduction.html
@@ -303,7 +303,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/Rails/ForceSslEnabledInProduction.html
+++ b/docs/RuboCop/Cop/Captive/Rails/ForceSslEnabledInProduction.html
@@ -303,7 +303,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/Rails/NoEmailFromController.html
+++ b/docs/RuboCop/Cop/Captive/Rails/NoEmailFromController.html
@@ -220,7 +220,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/Rails/NoEmailFromController.html
+++ b/docs/RuboCop/Cop/Captive/Rails/NoEmailFromController.html
@@ -220,7 +220,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/StringWhereInScope.html
+++ b/docs/RuboCop/Cop/Captive/StringWhereInScope.html
@@ -234,7 +234,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/StringWhereInScope.html
+++ b/docs/RuboCop/Cop/Captive/StringWhereInScope.html
@@ -234,7 +234,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/Translation.html
+++ b/docs/RuboCop/Cop/Captive/Translation.html
@@ -107,7 +107,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/Translation.html
+++ b/docs/RuboCop/Cop/Captive/Translation.html
@@ -107,7 +107,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/Translation/DeviseI18nPresence.html
+++ b/docs/RuboCop/Cop/Captive/Translation/DeviseI18nPresence.html
@@ -234,7 +234,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/Translation/DeviseI18nPresence.html
+++ b/docs/RuboCop/Cop/Captive/Translation/DeviseI18nPresence.html
@@ -234,7 +234,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/Translation/KaminariI18nPresence.html
+++ b/docs/RuboCop/Cop/Captive/Translation/KaminariI18nPresence.html
@@ -234,7 +234,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/Translation/KaminariI18nPresence.html
+++ b/docs/RuboCop/Cop/Captive/Translation/KaminariI18nPresence.html
@@ -234,7 +234,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/Translation/RailsI18nPresence.html
+++ b/docs/RuboCop/Cop/Captive/Translation/RailsI18nPresence.html
@@ -234,7 +234,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/RuboCop/Cop/Captive/Translation/RailsI18nPresence.html
+++ b/docs/RuboCop/Cop/Captive/Translation/RailsI18nPresence.html
@@ -234,7 +234,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -291,7 +291,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -291,7 +291,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -174,7 +174,7 @@ Each dependency should be explicitly set in the `Gemfile` and `bundle update` is
 </div></div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -174,7 +174,7 @@ Each dependency should be explicitly set in the `Gemfile` and `bundle update` is
 </div></div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -174,7 +174,7 @@ Each dependency should be explicitly set in the `Gemfile` and `bundle update` is
 </div></div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -174,7 +174,7 @@ Each dependency should be explicitly set in the `Gemfile` and `bundle update` is
 </div></div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -100,7 +100,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 16:43:28 2023 by
+  Generated on Tue Nov  7 17:21:02 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -100,7 +100,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Nov  7 17:21:02 2023 by
+  Generated on Tue Nov  7 17:21:12 2023 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.34 (ruby-3.2.2).
 </div>

--- a/lib/rubocop/cop/captive/rspec/specify_before_parameter.rb
+++ b/lib/rubocop/cop/captive/rspec/specify_before_parameter.rb
@@ -52,8 +52,9 @@ module RuboCop
           private
 
           def add_parameter(node)
+            magic_number = 6
             source = node.loc.expression.source
-            source.insert(source.index("before") + 6, "(:each)")
+            source.insert(source.index("before") + magic_number, "(:each)")
           end
         end
       end

--- a/rubocop-config-captive.gemspec
+++ b/rubocop-config-captive.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency("rubocop-rspec", "~> 2.22.0")
   gem.add_dependency("rubocop-capybara", "~> 2.18.0")
   gem.add_dependency("rubocop-factory_bot", "~> 2.23.1")
+  gem.add_dependency("rubocop-magic_numbers", "~> 0.4.0")
   gem.add_development_dependency("rspec", "~> 3.12")
   # gem.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
Pour pouvoir utilisé cette gem, il faut que les versions de Ruby supporte les versions 3.0 et 3.1 : https://github.com/meetcleo/rubocop-magic_numbers/pull/62