### PR TITLE
✨ Exclue la règle Layout/LineLength des fichiers .gemspec

### DIFF
--- a/config/rubocop-layout.yml
+++ b/config/rubocop-layout.yml
@@ -44,6 +44,7 @@ Layout/LineLength:
   # Disable LineLength on comments
   AllowedPatterns: ['^(\s*#)']
   Exclude:
+    - '**/*.gemspec'
     - 'spec/**/*.rb'
     - 'test/**/*.rb'
     - '**/*_spec.rb'


### PR DESCRIPTION
Cela m'a posé des soucis pour le captive-sdk