### PR TITLE
✨ Ignore le chiffre 100 pour magic_numbers

### DIFF
--- a/config/rubocop-magic_numbers.yml
+++ b/config/rubocop-magic_numbers.yml
@@ -7,6 +7,7 @@ MagicNumbers/NoArgument:
     - 0
     - -1
     - 1
+    - 100
   Exclude:
     - '**/spec/**/*.rb'
     - '**/test/**/*.rb'


### PR DESCRIPTION
car le chiffre 100 est un nombre très générique, souvent utilisé pour faire des calculs de pourcentage. Il n'y a pas un gros enjeu d'extraire ce chiffre dans une constante nommé

Cela permettra de simplifier son implémentation auprès de certains projets. Exemple de CI qui échoue à cause de ce nombre : [](https://git.captive.fr/captive/hedwige/-/jobs/484956)